### PR TITLE
Merge with_values when merging relations

### DIFF
--- a/lib/activerecord/cte/core_ext.rb
+++ b/lib/activerecord/cte/core_ext.rb
@@ -4,8 +4,31 @@ module ActiveRecord
   module Querying
     delegate :with, to: :all
   end
+  
+  module WithMerger
+    def normal_values
+      super + %i[with]
+    end
+
+    def merge
+      super
+      merge_withs
+      relation
+    end
+
+    private
+
+    def merge_withs
+      other_values = other.with_values.reject { |value| relation.with_values.include?(value) }
+      relation.with!(*other_values) if other_values.any?
+    end
+  end
 
   class Relation
+    class Merger
+      prepend WithMerger
+    end
+
     def with(opts, *rest)
       spawn.with!(opts, *rest)
     end

--- a/test/activerecord/cte_test.rb
+++ b/test/activerecord/cte_test.rb
@@ -135,11 +135,11 @@ class Activerecord::CteTest < ActiveSupport::TestCase
   end
 
   def test_with_when_merging_relations
-    popular_posts = Post.with(popular_posts: Post.where("views_count > 100")).joins("join popular_posts on posts.id = popular_posts.id")
-    archived_posts = Post.with(archived_posts: Post.where(archived: true)).joins("join archived_posts on posts.id = archived_posts.id")
+    most_popular = Post.with(most_popular: Post.where("views_count >= 100").select("id as post_id")).joins("join most_popular on most_popular.post_id = posts.id")
+    least_popular = Post.with(least_popular: Post.where("views_count <= 400").select("id as post_id")).joins("join least_popular on least_popular.post_id = posts.id")
+    merged = most_popular.merge(least_popular)
 
-    merged = popular_posts.merge(archived_posts).select("popular_posts.id as popular_id, archived_posts.id as archived_id")
-    
-    assert_nothing_raised { merged.to_a }
+    assert_equal merged.size, 1
+    assert_equal merged[0].views_count, 123
   end
 end

--- a/test/activerecord/cte_test.rb
+++ b/test/activerecord/cte_test.rb
@@ -133,4 +133,13 @@ class Activerecord::CteTest < ActiveSupport::TestCase
     assert_raise(ArgumentError) { Post.with(popular_posts: nil).load }
     assert_raise(ArgumentError) { Post.with(popular_posts: [Post.where("views_count > 100")]).load }
   end
+
+  def test_with_when_merging_relations
+    popular_posts = Post.with(popular_posts: Post.where("views_count > 100")).joins("join popular_posts on posts.id = popular_posts.id")
+    archived_posts = Post.with(archived_posts: Post.where(archived: true)).joins("join archived_posts on posts.id = archived_posts.id")
+
+    merged = popular_posts.merge(archived_posts).select("popular_posts.id as popular_id, archived_posts.id as archived_id")
+    
+    assert_nothing_raised { merged.to_a }
+  end
 end


### PR DESCRIPTION
CTE `WITH` statements get lost when merging relations. This ensures the ActiveRecord `Merger` keeps track of `with_values`.