### PR TITLE
Fix rails 6.1.4 compatibility

### DIFF
--- a/.github/workflows/test-with-mysql.yml
+++ b/.github/workflows/test-with-mysql.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        active_record: [6.0.4, 5.2.6]
+        active_record: [6.1.4, 6.0.4, 5.2.6]
     env:
       ACTIVE_RECORD_VERSION: ${{ matrix.active_record }}
       DATABASE_ADAPTER: mysql

--- a/.github/workflows/test-with-postgresql.yml
+++ b/.github/workflows/test-with-postgresql.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        active_record: [6.0.4, 5.2.6]
+        active_record: [6.1.4, 6.0.4, 5.2.6]
     env:
       ACTIVE_RECORD_VERSION: ${{ matrix.active_record }}
       DATABASE_ADAPTER: postgresql

--- a/.github/workflows/test-with-sqlite.yml
+++ b/.github/workflows/test-with-sqlite.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        active_record: [6.0.4, 5.2.6]
+        active_record: [6.1.4, 6.0.4, 5.2.6]
     env:
       ACTIVE_RECORD_VERSION: ${{ matrix.active_record }}
       DATABASE_ADAPTER: sqlite3

--- a/lib/activerecord/cte/core_ext.rb
+++ b/lib/activerecord/cte/core_ext.rb
@@ -46,8 +46,8 @@ module ActiveRecord
 
     private
 
-    def build_arel(aliases)
-      arel = super(aliases)
+    def build_arel(*args, **kwargs)
+      arel = super
       build_with(arel) if @values[:with]
       arel
     end


### PR DESCRIPTION
Rails 6.1.4 introduced this change : https://github.com/rails/rails/commit/99049262d37fedcd25af91231423103b0d218694#diff-79b53b2602bf702bdd8ce677e096be6a6923a54236e17237c16068a510078683R1228

`activerecord-cte` seems to override this private method, and I got the following error when doing stuff like  `object.relation.delete_all` : `wrong number of arguments (given 0, expected 1)`

This PR fixes this issue by being agnostic about the kind of params received by the `build_arel`method.

I would like to add a regression test but this means adding a new model for the relation and have a test just doing relation operations and ensure it doesn't raise ... is that ok with you or do you see a better testing strategy ? 

Thanks !
