### PR TITLE
Update CI matrix to increase test coverage

### DIFF
--- a/.github/workflows/test-with-mysql.yml
+++ b/.github/workflows/test-with-mysql.yml
@@ -6,7 +6,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        active_record: [6.1.4, 6.0.4]
+        active_record: [6.1.4, 6.0.4, 5.2.6]
+        ruby: [2.6, 2.7, '3.0']
+        exclude:
+          - active_record: 5.2.6
+            ruby: '3.0'
     env:
       ACTIVE_RECORD_VERSION: ${{ matrix.active_record }}
       DATABASE_ADAPTER: mysql
@@ -20,6 +24,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run tests
         run: bundle exec rake test

--- a/.github/workflows/test-with-postgresql.yml
+++ b/.github/workflows/test-with-postgresql.yml
@@ -3,11 +3,15 @@ on: [pull_request]
 jobs:
   Test-With-PostgreSQL:
     runs-on: ubuntu-latest
-    container: ruby:3.0
+    container: ruby:${{ matrix.ruby }}
     strategy:
       fail-fast: false
       matrix:
-        active_record: [6.1.4, 6.0.4]
+        active_record: [6.1.4, 6.0.4, 5.2.6]
+        ruby: [2.6, 2.7, '3.0']
+        exclude:
+          - active_record: 5.2.6
+            ruby: '3.0'
     env:
       ACTIVE_RECORD_VERSION: ${{ matrix.active_record }}
       DATABASE_ADAPTER: postgresql
@@ -28,6 +32,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+      - name: Update bundler
+        run: gem update bundler # Use the latest bundler
       - name: Bundle dependencies
         run: bundle install
       - name: Run tests


### PR DESCRIPTION
Currently, the SQLite test supports running the test matrix with the following version. 
- active_record: [`6.1.4`, `6.0.4`, `5.2.6`]
- ruby: [`2.6`, `2.7`, `3.0`]

I update MySql and PostgreSQL CI configuration to increase the test coverage as SQLite. 
Hope this PR help 😃 