### PR TITLE
Fix RECURSIVE missing

### DIFF
--- a/lib/activerecord/cte/core_ext.rb
+++ b/lib/activerecord/cte/core_ext.rb
@@ -55,8 +55,9 @@ module ActiveRecord
     def build_with(arel) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
       return if with_values.empty?
 
-      recursive = with_values.delete(:recursive)
-      with_statements = with_values.map do |with_value|
+      values = with_values.dup
+      recursive = values.delete(:recursive)
+      with_statements = values.map do |with_value|
         case with_value
         when String then Arel::Nodes::SqlLiteral.new(with_value)
         when Arel::Nodes::As then with_value

--- a/test/activerecord/cte_test.rb
+++ b/test/activerecord/cte_test.rb
@@ -95,7 +95,7 @@ class Activerecord::CteTest < ActiveSupport::TestCase
     recursive_term = posts.project(posts[:id], posts[:archived]).join(popular_posts).on(posts[:id].eq(popular_posts[:id]))
 
     recursive_rel = Post.with(:recursive, popular_posts: anchor_term.union(recursive_term)).from("popular_posts AS posts")
-    
+
     assert_equal Post.select(:id).where("views_count > 100").where(archived: true).to_a, recursive_rel.where(archived: true)
     assert_equal Post.select(:id).where("views_count > 100").to_a, recursive_rel
   end

--- a/test/activerecord/cte_test.rb
+++ b/test/activerecord/cte_test.rb
@@ -91,10 +91,12 @@ class Activerecord::CteTest < ActiveSupport::TestCase
   def test_recursive_with_call
     posts = Arel::Table.new(:posts)
     popular_posts = Arel::Table.new(:popular_posts)
-    anchor_term = posts.project(posts[:id]).where(posts[:views_count].gt(100))
-    recursive_term = posts.project(posts[:id]).join(popular_posts).on(posts[:id].eq(popular_posts[:id]))
+    anchor_term = posts.project(posts[:id], posts[:archived]).where(posts[:views_count].gt(100))
+    recursive_term = posts.project(posts[:id], posts[:archived]).join(popular_posts).on(posts[:id].eq(popular_posts[:id]))
 
     recursive_rel = Post.with(:recursive, popular_posts: anchor_term.union(recursive_term)).from("popular_posts AS posts")
+    
+    assert_equal Post.select(:id).where("views_count > 100").where(archived: true).to_a, recursive_rel.where(archived: true)
     assert_equal Post.select(:id).where("views_count > 100").to_a, recursive_rel
   end
 


### PR DESCRIPTION
I added a test to reproduce the error. It is reproduced on postgres. Removing RECURSIVE is not important at all for sqllite.

An error occurs if you reuse an object that has a .with(:recursion). The first time .to_sql add the RECURSIVE, but next time the RECURSIVE will be lost